### PR TITLE
Bump clair version to 2.0.5

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/coreos/clair:v2.0.1
+FROM quay.io/coreos/clair:v2.0.5
 
 ENV CLAIR_DCOS_PATH /clair-dcos
 


### PR DESCRIPTION
2.0.1 can't download Ubuntu nor Alpine vulnerabilities anymore. Bumping to 2.0.5. Tested in our DC/OS cluster.